### PR TITLE
[Suggestion] Adding Resources Group

### DIFF
--- a/src/Annotation/Group.php
+++ b/src/Annotation/Group.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Dingo\Blueprint\Annotation;
+
+/**
+ * @Annotation
+ */
+class Group
+{
+    /**
+     * @var string
+     */
+    public $identifier;
+}

--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -87,10 +87,14 @@ class Blueprint
 
             $annotations = new Collection($this->reader->getClassAnnotations($controller));
 
-            return new Resource($controller->getName(), $controller, $annotations, $actions);
+            $resource = new Resource($controller->getName(), $controller, $annotations, $actions);
+
+            return new Collection(['group' => $resource->getGroup(), 'resource' => $resource]);
         });
 
-        return $this->generateContentsFromResources($resources, $name);
+        $groups = $resources->groupBy('group');
+
+        return $this->generateContentsFromResources($groups, $name);
     }
 
     /**
@@ -101,7 +105,7 @@ class Blueprint
      *
      * @return string
      */
-    protected function generateContentsFromResources(Collection $resources, $name)
+    protected function generateContentsFromResources(Collection $groups, $name)
     {
         $contents = '';
 
@@ -110,53 +114,62 @@ class Blueprint
         $contents .= sprintf('# %s', $name);
         $contents .= $this->line(2);
 
-        $resources->each(function ($resource) use (&$contents) {
-            $contents .= $resource->getDefinition();
-
-            if ($description = $resource->getDescription()) {
-                $contents .= $this->line();
-                $contents .= $description;
-            }
-
-            if (($parameters = $resource->getParameters()) && ! $parameters->isEmpty()) {
-                $this->appendParameters($contents, $parameters);
-            }
-
-            $resource->getActions()->each(function ($action) use (&$contents) {
+        $groups->each(function ($resources, $group) use (&$contents) {
+            if ($group) {
+                $contents .= sprintf('# Group %s', $group);
                 $contents .= $this->line(2);
-                $contents .= $action->getDefinition();
+            }
 
-                if ($description = $action->getDescription()) {
+            $resources->each(function ($resource) use (&$contents) {
+                $resource = $resource['resource'];
+
+                $contents .= $resource->getDefinition();
+
+                if ($description = $resource->getDescription()) {
                     $contents .= $this->line();
                     $contents .= $description;
                 }
 
-                if (($parameters = $action->getParameters()) && ! $parameters->isEmpty()) {
+                if (($parameters = $resource->getParameters()) && ! $parameters->isEmpty()) {
                     $this->appendParameters($contents, $parameters);
                 }
 
-                if ($request = $action->getRequest()) {
-                    $this->appendRequest($contents, $request);
-                }
+                $resource->getActions()->each(function ($action) use (&$contents) {
+                    $contents .= $this->line(2);
+                    $contents .= $action->getDefinition();
 
-                if ($response = $action->getResponse()) {
-                    $this->appendResponse($contents, $response);
-                }
+                    if ($description = $action->getDescription()) {
+                        $contents .= $this->line();
+                        $contents .= $description;
+                    }
 
-                if ($transaction = $action->getTransaction()) {
-                    foreach ($transaction->value as $value) {
-                        if ($value instanceof Annotation\Request) {
-                            $this->appendRequest($contents, $value);
-                        } elseif ($value instanceof Annotation\Response) {
-                            $this->appendResponse($contents, $value);
-                        } else {
-                            throw new RuntimeException('Unsupported annotation type given in transaction.');
+                    if (($parameters = $action->getParameters()) && ! $parameters->isEmpty()) {
+                        $this->appendParameters($contents, $parameters);
+                    }
+
+                    if ($request = $action->getRequest()) {
+                        $this->appendRequest($contents, $request);
+                    }
+
+                    if ($response = $action->getResponse()) {
+                        $this->appendResponse($contents, $response);
+                    }
+
+                    if ($transaction = $action->getTransaction()) {
+                        foreach ($transaction->value as $value) {
+                            if ($value instanceof Annotation\Request) {
+                                $this->appendRequest($contents, $value);
+                            } elseif ($value instanceof Annotation\Response) {
+                                $this->appendResponse($contents, $value);
+                            } else {
+                                throw new RuntimeException('Unsupported annotation type given in transaction.');
+                            }
                         }
                     }
-                }
-            });
+                });
 
-            $contents .= $this->line(2);
+                $contents .= $this->line(2);
+            });
         });
 
         return stripslashes(trim($contents));

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -70,6 +70,20 @@ class Resource extends Section
     }
 
     /**
+     * Get the resource group.
+     *
+     * @return string
+     */
+    public function getGroup()
+    {
+        if (($annotation = $this->getAnnotationByType('Group')) && isset($annotation->identifier)) {
+            return $annotation->identifier;
+        }
+
+        return;
+    }
+
+    /**
      * Get the resource definition.
      *
      * @return string

--- a/tests/BlueprintTest.php
+++ b/tests/BlueprintTest.php
@@ -21,6 +21,8 @@ FORMAT: 1A
 
 # testing
 
+# Group Accounts
+
 # Users [/users]
 Users Resource
 
@@ -114,6 +116,8 @@ EOT;
 FORMAT: 1A
 
 # testing
+
+# Group Accounts
 
 # Users [/users]
 Users Resource
@@ -261,6 +265,8 @@ EOT;
 FORMAT: 1A
 
 # testing
+
+# Group Accounts
 
 # Users [/users]
 Users Resource

--- a/tests/Stubs/UserPhotosResourceStub.php
+++ b/tests/Stubs/UserPhotosResourceStub.php
@@ -5,6 +5,7 @@ namespace Dingo\Blueprint\Tests\Stubs;
 /**
  * User Photos Resource
  *
+ * @Group("Accounts")
  * @Resource("User Photos", uri="/users/{userId}/photos")
  * @Parameters({
  *      @Parameter("userId", description="ID of user who owns the photos.", type="integer", required=true)

--- a/tests/Stubs/UsersResourceStub.php
+++ b/tests/Stubs/UsersResourceStub.php
@@ -5,6 +5,7 @@ namespace Dingo\Blueprint\Tests\Stubs;
 /**
  * Users Resource
  *
+ * @Group("Accounts")
  * @Resource("Users", uri="/users")
  */
 class UsersResourceStub


### PR DESCRIPTION
https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#def-resourcegroup-section

Example usage:

```
/**
 * Users Resource
 *
 * @Group("Accounts")
 * @Resource("Users", uri="/users")
 */
```

```
/**
 * User Photos Resource
 *
 * @Group("Accounts")
 * @Resource("User Photos", uri="/users/{userId}/photos")
 */
```

This will sort all resources under the group you specify. It's a simple implementation so there are a couple of things that are missing and could be added if anyone has the time:
- A Resource Group Description (could be added as a parameter `@Group("Accounts", description="...")`
- Update the markdown title prefix accordingly (`#`, `##`...) for following resources / actions. (The apiary doc generator or aglio still renders it correctly, but generated markdown looks a bit awful)

Signed-off-by: Martin Bastien martin.bastien@studiofrenetic.com
