### PR TITLE
Adding support for enum list parameters

### DIFF
--- a/src/Annotation/Member.php
+++ b/src/Annotation/Member.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Dingo\Blueprint\Annotation;
+
+/**
+ * @Annotation
+ */
+class Member
+{
+    /**
+     * @var string
+     */
+    public $identifier;
+
+    /**
+     * @var string
+     */
+    public $description;
+}

--- a/src/Annotation/Parameter.php
+++ b/src/Annotation/Parameter.php
@@ -31,4 +31,9 @@ class Parameter
      * @var mixed
      */
     public $default;
+
+    /**
+     * @array<Member>
+     */
+    public $members;
 }

--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -187,6 +187,22 @@ class Blueprint
             if (isset($parameter->default)) {
                 $this->appendSection($contents, sprintf('Default: %s', $parameter->default), 2, 1);
             }
+
+            if ($parameter->type == 'enum') {
+                $contents .= $this->line();
+                $contents .= $this->tab(2);
+                $contents .= '+ Members';
+
+                foreach ($parameter->members as $member) {
+                    $contents .= $this->line();
+                    $contents .= $this->tab(3);
+                    $contents .= sprintf(
+                        '+ `%s` - %s',
+                        $member->identifier,
+                        $member->description
+                    );
+                }
+            }
         });
     }
 


### PR DESCRIPTION
This PR would allow us to detail the members available for an enum type parameter using the following syntax.  It does require that the type be set to enum in order to even trigger looking for members.

```
* @Parameters({
*     @Parameter("include", type="enum", description="Available
additional details to request.", members={
*          @Member("project", description="The project the issue
belongs to.")
*     })
* })
```
