### PR TITLE
Add attribute support to annotations

### DIFF
--- a/src/Annotation/Attribute.php
+++ b/src/Annotation/Attribute.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Dingo\Blueprint\Annotation;
+
+/**
+ * @Annotation
+ */
+class Attribute
+{
+    /**
+     * @var string
+     */
+    public $identifier;
+
+    /**
+     * @var string
+     */
+    public $type = 'string';
+
+    /**
+     * @var string
+     */
+    public $description;
+}

--- a/src/Annotation/Attributes.php
+++ b/src/Annotation/Attributes.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Dingo\Blueprint\Annotation;
+
+/**
+ * @Annotation
+ */
+class Attributes
+{
+    /**
+     * @array<Attribute>
+     */
+    public $value;
+}

--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -130,6 +130,10 @@ class Blueprint
                     $contents .= $description;
                 }
 
+                if (($attributes = $action->getAttributes()) && ! $attributes->isEmpty()) {
+                    $this->appendAttributes($contents, $attributes);
+                }
+
                 if (($parameters = $action->getParameters()) && ! $parameters->isEmpty()) {
                     $this->appendParameters($contents, $parameters);
                 }
@@ -159,6 +163,30 @@ class Blueprint
         });
 
         return stripslashes(trim($contents));
+    }
+
+    /**
+     * Append the attributes subsection to a resource or action.
+     *
+     * @param string                         $contents
+     * @param \Illuminate\Support\Collection $attributes
+     *
+     * @return void
+     */
+    protected function appendAttributes(&$contents, Collection $attributes)
+    {
+        $this->appendSection($contents, 'Attributes');
+
+        $attributes->each(function ($attribute) use (&$contents) {
+            $contents .= $this->line();
+            $contents .= $this->tab();
+            $contents .= sprintf(
+                '+ %s (%s) - %s',
+                $attribute->identifier,
+                $attribute->type,
+                $attribute->description
+            );
+        });
     }
 
     /**

--- a/src/Section.php
+++ b/src/Section.php
@@ -39,4 +39,22 @@ abstract class Section
 
         return $parameters;
     }
+
+    /**
+     * Get a sections attribute annotations.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getAttributes()
+    {
+        $attributes = new Collection;
+
+        if ($annotation = $this->getAnnotationByType('Attributes')) {
+            foreach ($annotation->value as $attribute) {
+                $attributes[] = $attribute;
+            }
+        }
+
+        return $attributes;
+    }
 }

--- a/tests/BlueprintTest.php
+++ b/tests/BlueprintTest.php
@@ -225,6 +225,10 @@ Show all photos for a given user.
 ## Upload new photo [POST /users/{userId}/photos]
 Upload a new photo for a given user.
 
++ Attributes
+    + name (string) - The name of the photo
+    + src (string) - The location of the photo
+
 + Request (application/json)
     + Body
 
@@ -396,6 +400,10 @@ Show an individual photo that belongs to a given user.
 
 ## Upload new photo [POST /users/{userId}/photos]
 Upload a new photo for a given user.
+
++ Attributes
+    + name (string) - The name of the photo
+    + src (string) - The location of the photo
 
 + Request (application/json)
     + Body

--- a/tests/Stubs/UserPhotosResourceStub.php
+++ b/tests/Stubs/UserPhotosResourceStub.php
@@ -66,6 +66,10 @@ class UserPhotosResourceStub
      *
      * @Post("/")
      * @Versions({"v1", "v2"})
+     * @Attributes({
+     *      @Attribute("name", type="string", description="The name of the photo"),
+     *      @Attribute("src", type="string", description="The location of the photo")
+     * })
      * @Transaction({
      *      @Request({"name": "photo", "src": "cool/new/photo.jpg"}),
      *      @Response(201, body={


### PR DESCRIPTION
Added the ability to set attributes much like parameters are set.

https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#def-attributes-section

```
     * @Attributes({
     *      @Attribute("title", type="string", description="The title of the issue."),
     *      @Attribute("project_id", type="string", description="The ID of the project to assign it to."),
     *      @Attribute("project_key", type="string", description="The key of the assigned project."),
     *      @Attribute("description", type="string", description="Detailed notes on what the issue should accomplish.")
     * })
```
