### PR TITLE
Add missing attributes elements

### DIFF
--- a/src/Annotation/Attribute.php
+++ b/src/Annotation/Attribute.php
@@ -18,7 +18,17 @@ class Attribute
     public $type = 'string';
 
     /**
+     * @var bool
+     */
+    public $required = false;
+
+    /**
      * @var string
      */
     public $description;
+
+    /**
+     * @var mixed
+     */
+    public $sample;
 }

--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -180,10 +180,16 @@ class Blueprint
         $attributes->each(function ($attribute) use (&$contents) {
             $contents .= $this->line();
             $contents .= $this->tab();
+            $contents .= sprintf('+ %s', $attribute->identifier);
+
+            if ($attribute->sample) {
+                $contents .= sprintf(': %s', $attribute->sample);
+            }
+
             $contents .= sprintf(
-                '+ %s (%s) - %s',
-                $attribute->identifier,
+                ' (%s, %s) - %s',
                 $attribute->type,
+                $attribute->required ? 'required' : 'optional',
                 $attribute->description
             );
         });

--- a/tests/BlueprintTest.php
+++ b/tests/BlueprintTest.php
@@ -226,8 +226,8 @@ Show all photos for a given user.
 Upload a new photo for a given user.
 
 + Attributes
-    + name (string) - The name of the photo
-    + src (string) - The location of the photo
+    + name: photo (string, optional) - The name of the photo
+    + src (string, required) - The location of the photo
 
 + Request (application/json)
     + Body
@@ -402,8 +402,8 @@ Show an individual photo that belongs to a given user.
 Upload a new photo for a given user.
 
 + Attributes
-    + name (string) - The name of the photo
-    + src (string) - The location of the photo
+    + name: photo (string, optional) - The name of the photo
+    + src (string, required) - The location of the photo
 
 + Request (application/json)
     + Body

--- a/tests/Stubs/UserPhotosResourceStub.php
+++ b/tests/Stubs/UserPhotosResourceStub.php
@@ -67,8 +67,8 @@ class UserPhotosResourceStub
      * @Post("/")
      * @Versions({"v1", "v2"})
      * @Attributes({
-     *      @Attribute("name", type="string", description="The name of the photo"),
-     *      @Attribute("src", type="string", description="The location of the photo")
+     *      @Attribute("name", type="string", description="The name of the photo", sample="photo"),
+     *      @Attribute("src", type="string", description="The location of the photo", required=true)
      * })
      * @Transaction({
      *      @Request({"name": "photo", "src": "cool/new/photo.jpg"}),


### PR DESCRIPTION
1. Add a sample for an attribute. ex:

`+ name: mySampleName (string) - The person's name`

Reference: https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#example-14
1. The `required` field doesn't seem to be documented (or I just didn't look hard enough), but any parser will render it as the `required` array in the json schema specifications, so it seems like it's all good.
