### PR TITLE
Add attributes for request and response

### DIFF
--- a/src/Annotation/Request.php
+++ b/src/Annotation/Request.php
@@ -26,4 +26,9 @@ class Request
      * @var array
      */
     public $headers = [];
+
+    /**
+     * @var array<Dingo\Blueprint\Annotation\Attribute>
+     */
+    public $attributes;
 }

--- a/src/Annotation/Response.php
+++ b/src/Annotation/Response.php
@@ -26,4 +26,9 @@ class Response
      * @var array
      */
     public $headers = [];
+
+    /**
+     * @var array<Dingo\Blueprint\Annotation\Attribute>
+     */
+    public $attributes;
 }

--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -170,16 +170,17 @@ class Blueprint
      *
      * @param string                         $contents
      * @param \Illuminate\Support\Collection $attributes
+     * @param int                            $indent
      *
      * @return void
      */
-    protected function appendAttributes(&$contents, Collection $attributes)
+    protected function appendAttributes(&$contents, Collection $attributes, $indent = 0)
     {
-        $this->appendSection($contents, 'Attributes');
+        $this->appendSection($contents, 'Attributes', $indent);
 
-        $attributes->each(function ($attribute) use (&$contents) {
+        $attributes->each(function ($attribute) use (&$contents, $indent) {
             $contents .= $this->line();
-            $contents .= $this->tab();
+            $contents .= $this->tab(1 + $indent);
             $contents .= sprintf('+ %s', $attribute->identifier);
 
             if ($attribute->sample) {
@@ -251,6 +252,10 @@ class Blueprint
             $this->appendHeaders($contents, $request->headers);
         }
 
+        if (isset($response->attributes)) {
+            $this->appendAttributes($contents, collect($response->attributes), 1);
+        }
+
         if (isset($response->body)) {
             $this->appendBody($contents, $this->prepareBody($response->body, $response->contentType));
         }
@@ -276,6 +281,10 @@ class Blueprint
 
         if (! empty($request->headers)) {
             $this->appendHeaders($contents, $request->headers);
+        }
+
+        if (isset($request->attributes)) {
+            $this->appendAttributes($contents, collect($request->attributes), 1);
         }
 
         if (isset($request->body)) {

--- a/tests/BlueprintTest.php
+++ b/tests/BlueprintTest.php
@@ -70,6 +70,11 @@ Get a JSON representation of an existing user.
 Create a new user.
 
 + Request (application/json)
+
+    + Attributes
+        + name: jason (string, required) - The user name
+        + email: jason@jason.com (string, required) - The user email
+        + password: 1234567 (string, required) - The user password
     + Body
 
             {
@@ -164,6 +169,11 @@ Get a JSON representation of an existing user.
 Create a new user.
 
 + Request (application/json)
+
+    + Attributes
+        + name: jason (string, required) - The user name
+        + email: jason@jason.com (string, required) - The user email
+        + password: 1234567 (string, required) - The user password
     + Body
 
             {
@@ -318,6 +328,11 @@ Get a JSON representation of an existing user.
 Create a new user.
 
 + Request (application/json)
+
+    + Attributes
+        + name: jason (string, required) - The user name
+        + email: jason@jason.com (string, required) - The user email
+        + password: 1234567 (string, required) - The user password
     + Body
 
             {
@@ -383,6 +398,11 @@ Show an individual photo that belongs to a given user.
     + photoId (integer, required) - ID of photo to show.
 
 + Response 200 (application/json)
+
+    + Attributes
+        + id: 1 (number, optional) - The photo id
+        + name: photo (string, optional) - The photo name
+        + src: path/to/cool/photo.jpg (string, optional) - The photo path
     + Body
 
             {

--- a/tests/Stubs/UserPhotosResourceStub.php
+++ b/tests/Stubs/UserPhotosResourceStub.php
@@ -50,6 +50,10 @@ class UserPhotosResourceStub
      *          "id": 1,
      *          "name": "photo",
      *          "src": "path/to/cool/photo.jpg"
+     *      }, attributes={
+     *          @Attribute("id", type="number", description="The photo id", sample="1"),
+     *          @Attribute("name", type="string", description="The photo name", sample="photo"),
+     *          @Attribute("src", type="string", description="The photo path", sample="path/to/cool/photo.jpg")
      *      }),
      *      @Response(404, body={"message": "Photo could not be found."})
      * })

--- a/tests/Stubs/UsersResourceStub.php
+++ b/tests/Stubs/UsersResourceStub.php
@@ -56,6 +56,10 @@ class UsersResourceStub
      *          "name": "jason",
      *          "email": "jason@jason.com",
      *          "password": "1234567"
+     *      }, attributes={
+     *          @Attribute("name", type="string", description="The user name", sample="jason", required=true),
+     *          @Attribute("email", type="string", description="The user email", sample="jason@jason.com", required=true),
+     *          @Attribute("password", type="string", description="The user password", sample="1234567", required=true)
      *      }),
      *      @Response(200, body={"id": 10, "name": "jason", "email": "jason@jason.com"}),
      *      @Response(422, body={

--- a/tests/Stubs/UsersResourceStub.php
+++ b/tests/Stubs/UsersResourceStub.php
@@ -52,7 +52,7 @@ class UsersResourceStub
      *
      * @Post("/")
      * @Transaction({
-     *      @Request({
+     *      @Request(body={
      *          "name": "jason",
      *          "email": "jason@jason.com",
      *          "password": "1234567"


### PR DESCRIPTION
This allows to add Attributes specifically for a Request or a Response object.

Example

```
@Request(body={
    "name": "jason",
}, attributes={
    @Attribute("name", type="string", description="The user name", sample="jason")
})
```
