### PR TITLE
Fixed escaped unicode

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -357,7 +357,7 @@ class Blueprint
     protected function prepareBody($body, $contentType)
     {
         if ($contentType == 'application/json') {
-            return json_encode($body, JSON_PRETTY_PRINT);
+            return json_encode($body, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
         }
 
         return $body;


### PR DESCRIPTION
Referring to the Dingo/api issue #684 api:docs generate escaped unicode
