### PR TITLE
Allow to have something after application/json

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -356,7 +356,7 @@ class Blueprint
      */
     protected function prepareBody($body, $contentType)
     {
-        if ($contentType == 'application/json') {
+        if (strpos($contentType, 'application/json') === 0) {
             return json_encode($body, JSON_PRETTY_PRINT);
         }
 


### PR DESCRIPTION
I cannot generate the doc if I want to put something like "charset=utf-8" after "application/json".

If I put contentType="application/json; charset=utf-8" in the Response annotation it doesn't detect that the Response body is in json.
