### PR TITLE
Add support for optional <example_value> in parameters

### DIFF
--- a/src/Annotation/Parameter.php
+++ b/src/Annotation/Parameter.php
@@ -33,6 +33,11 @@ class Parameter
     public $default;
 
     /**
+     * @var mixed
+     */
+    public $example;
+
+    /**
      * @array<Member>
      */
     public $members;

--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -212,8 +212,9 @@ class Blueprint
             $contents .= $this->line();
             $contents .= $this->tab();
             $contents .= sprintf(
-                '+ %s (%s, %s) - %s',
+                '+ %s:%s (%s, %s) - %s',
                 $parameter->identifier,
+                $parameter->example ? " `{$parameter->example}`" : '',
                 $parameter->members ? sprintf('enum[%s]', $parameter->type) : $parameter->type,
                 $parameter->required ? 'required' : 'optional',
                 $parameter->description

--- a/tests/BlueprintTest.php
+++ b/tests/BlueprintTest.php
@@ -49,7 +49,7 @@ Get a JSON representation of all registered users.
 Get a JSON representation of an existing user.
 
 + Parameters
-    + id (integer, required) - ID of user to retrieve
+    + id: `5` (integer, required) - ID of user to retrieve
 
 + Response 200 (application/json)
     + Body
@@ -148,7 +148,7 @@ Get a JSON representation of all registered users.
 Get a JSON representation of an existing user.
 
 + Parameters
-    + id (integer, required) - ID of user to retrieve
+    + id: `5` (integer, required) - ID of user to retrieve
 
 + Response 200 (application/json)
     + Body
@@ -207,15 +207,15 @@ Create a new user.
 User Photos Resource
 
 + Parameters
-    + userId (integer, required) - ID of user who owns the photos.
+    + userId: (integer, required) - ID of user who owns the photos.
 
 ## Show all photos [GET /users/{userId}/photos{?sort,order}]
 Show all photos for a given user.
 
 + Parameters
-    + sort (string, optional) - Column to sort by.
+    + sort: (string, optional) - Column to sort by.
         + Default: name
-    + order (enum[string], optional) - Order of results, either `asc` or `desc`.
+    + order: (enum[string], optional) - Order of results, either `asc` or `desc`.
         + Default: desc
         + Members
             + `asc` - Ascending order.
@@ -307,7 +307,7 @@ Get a JSON representation of all registered users.
 Get a JSON representation of an existing user.
 
 + Parameters
-    + id (integer, required) - ID of user to retrieve
+    + id: `5` (integer, required) - ID of user to retrieve
 
 + Response 200 (application/json)
     + Body
@@ -366,15 +366,15 @@ Create a new user.
 User Photos Resource
 
 + Parameters
-    + userId (integer, required) - ID of user who owns the photos.
+    + userId: (integer, required) - ID of user who owns the photos.
 
 ## Show all photos [GET /users/{userId}/photos{?sort,order}]
 Show all photos for a given user.
 
 + Parameters
-    + sort (string, optional) - Column to sort by.
+    + sort: (string, optional) - Column to sort by.
         + Default: name
-    + order (enum[string], optional) - Order of results, either `asc` or `desc`.
+    + order: (enum[string], optional) - Order of results, either `asc` or `desc`.
         + Default: desc
         + Members
             + `asc` - Ascending order.
@@ -395,7 +395,7 @@ Show all photos for a given user.
 Show an individual photo that belongs to a given user.
 
 + Parameters
-    + photoId (integer, required) - ID of photo to show.
+    + photoId: (integer, required) - ID of photo to show.
 
 + Response 200 (application/json)
 
@@ -453,7 +453,7 @@ Upload a new photo for a given user.
 Delete an existing photo for a given user.
 
 + Parameters
-    + photoId (integer, required) - ID of photo to delete.
+    + photoId: (integer, required) - ID of photo to delete.
 
 + Response 204 (application/json)
 

--- a/tests/Stubs/UsersResourceStub.php
+++ b/tests/Stubs/UsersResourceStub.php
@@ -33,7 +33,7 @@ class UsersResourceStub
      *
      * @Get("/{id}")
      * @Parameters({
-     *      @Parameter("id", description="ID of user to retrieve", type="integer", required=true)
+     *      @Parameter("id", description="ID of user to retrieve", type="integer", required=true, example=5)
      * })
      * @Transaction({
      *      @Response(200, body={"id": 5, "name": "jason"}),


### PR DESCRIPTION
I was asking about this in #20 but didn't get a response and really need this to make my blueprint (generated from `dingo/api`) valid for Dredd to test against.  

Currently I get `error: Runtime compilation error: Required URI parameter 'id' has no example value.` and this patch fixes that.

Let me know if there's anything else that should be done before this is added and I'll try to take another look.
