### PR TITLE
Default response and request headers for a resource

### DIFF
--- a/src/Annotation/Resource.php
+++ b/src/Annotation/Resource.php
@@ -21,4 +21,14 @@ class Resource
      * @var string
      */
     public $method;
+
+    /**
+     * @var array
+     */
+    public $requestHeaders = [];
+
+    /**
+     * @var array
+     */
+    public $responseHeaders = [];
 }

--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -121,7 +121,7 @@ class Blueprint
                 $this->appendParameters($contents, $parameters);
             }
 
-            $resource->getActions()->each(function ($action) use (&$contents) {
+            $resource->getActions()->each(function ($action) use (&$contents, $resource) {
                 $contents .= $this->line(2);
                 $contents .= $action->getDefinition();
 
@@ -139,19 +139,19 @@ class Blueprint
                 }
 
                 if ($request = $action->getRequest()) {
-                    $this->appendRequest($contents, $request);
+                    $this->appendRequest($contents, $request, $resource);
                 }
 
                 if ($response = $action->getResponse()) {
-                    $this->appendResponse($contents, $response);
+                    $this->appendResponse($contents, $response, $resource);
                 }
 
                 if ($transaction = $action->getTransaction()) {
                     foreach ($transaction->value as $value) {
                         if ($value instanceof Annotation\Request) {
-                            $this->appendRequest($contents, $value);
+                            $this->appendRequest($contents, $value, $resource);
                         } elseif ($value instanceof Annotation\Response) {
-                            $this->appendResponse($contents, $value);
+                            $this->appendResponse($contents, $value, $resource);
                         } else {
                             throw new RuntimeException('Unsupported annotation type given in transaction.');
                         }
@@ -237,10 +237,11 @@ class Blueprint
      *
      * @param string                               $contents
      * @param \Dingo\Blueprint\Annotation\Response $response
+     * @param Resource                             $resource
      *
      * @return void
      */
-    protected function appendResponse(&$contents, Annotation\Response $response)
+    protected function appendResponse(&$contents, Annotation\Response $response, Resource $resource)
     {
         $this->appendSection($contents, sprintf('Response %s', $response->statusCode));
 
@@ -248,8 +249,8 @@ class Blueprint
             $contents .= ' ('.$response->contentType.')';
         }
 
-        if (! empty($request->headers)) {
-            $this->appendHeaders($contents, $request->headers);
+        if (! empty($response->headers) || $resource->hasResponseHeaders()) {
+            $this->appendHeaders($contents, array_merge($resource->getResponseHeaders(), $response->headers));
         }
 
         if (isset($response->attributes)) {
@@ -266,10 +267,11 @@ class Blueprint
      *
      * @param string                              $contents
      * @param \Dingo\Blueprint\Annotation\Request $request
+     * @param Resource                            $resource
      *
      * @return void
      */
-    protected function appendRequest(&$contents, $request)
+    protected function appendRequest(&$contents, $request, Resource $resource)
     {
         $this->appendSection($contents, 'Request');
 
@@ -279,8 +281,8 @@ class Blueprint
 
         $contents .= ' ('.$request->contentType.')';
 
-        if (! empty($request->headers)) {
-            $this->appendHeaders($contents, $request->headers);
+        if (! empty($request->headers) || $resource->hasRequestHeaders()) {
+            $this->appendHeaders($contents, array_merge($resource->getRequestHeaders(), $request->headers));
         }
 
         if (isset($request->attributes)) {
@@ -323,7 +325,7 @@ class Blueprint
      * Append a headers subsection to an action.
      *
      * @param string $contents
-     * @param array  $response
+     * @param array  $headers
      *
      * @return void
      */

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -37,6 +37,20 @@ class Resource extends Section
     protected $actions;
 
     /**
+     * Collection of default request headers belonging to a resource.
+     *
+     * @var array
+     */
+    protected $requestHeaders = [];
+
+    /**
+     * Collection of default response headers belonging to a resource.
+     *
+     * @var array
+     */
+    protected $responseHeaders = [];
+
+    /**
      * Create a new resource instance.
      *
      * @param string                         $identifier
@@ -142,5 +156,53 @@ class Resource extends Section
         }
 
         return $this->identifier;
+    }
+
+    /**
+     * Check if resource has default request headers set.
+     *
+     * @return bool
+     */
+    public function hasRequestHeaders()
+    {
+        return count($this->getRequestHeaders()) > 0;
+    }
+
+    /**
+     * Get the resource default request headers.
+     *
+     * @return array
+     */
+    public function getRequestHeaders()
+    {
+        if (($annotation = $this->getAnnotationByType('Resource')) && isset($annotation->requestHeaders)) {
+            return $annotation->requestHeaders;
+        }
+
+        return $this->requestHeaders;
+    }
+
+    /**
+     * Check if resource has default response headers set.
+     *
+     * @return bool
+     */
+    public function hasResponseHeaders()
+    {
+        return count($this->getResponseHeaders()) > 0;
+    }
+
+    /**
+     * Get the resource default response headers.
+     *
+     * @return array
+     */
+    public function getResponseHeaders()
+    {
+        if (($annotation = $this->getAnnotationByType('Resource')) && isset($annotation->responseHeaders)) {
+            return $annotation->responseHeaders;
+        }
+
+        return $this->responseHeaders;
     }
 }


### PR DESCRIPTION
When you create a API with a custom Accept type or you use OAuth2 and you pass the access token in headers, you have to define them for every request and it quickly becomes tedious to write the same headers for every request/response combination...

This adds the ability to set default request and response headers for a resource which are then merged with headers defined in request or response.

Also fixed a possible bug in `src/Blueprint.php:251` where `$request` is not defined.
