### PR TITLE
appendResponse does not include headers

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -248,8 +248,8 @@ class Blueprint
             $contents .= ' ('.$response->contentType.')';
         }
 
-        if (! empty($request->headers)) {
-            $this->appendHeaders($contents, $request->headers);
+        if (! empty($response->headers)) {
+            $this->appendHeaders($contents, $response->headers);
         }
 
         if (isset($response->attributes)) {


### PR DESCRIPTION
I was trying to include tymon/jwt-auth token refresh functionality inside the blueprint. However, I was not able to get the headers printed. After taking a look, it became apparent that it was attempting to include `$request->headers` rather than `$response->headers`. PR fixes this.
