### PR TITLE
Remove empty actions

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -86,6 +86,10 @@ class Blueprint
 
             $annotations = new Collection($this->reader->getClassAnnotations($controller));
 
+            if(count($actions) === 0){
+                return false;
+            }
+
             return new Resource($controller->getName(), $controller, $annotations, $actions);
         });
 
@@ -110,6 +114,10 @@ class Blueprint
         $contents .= $this->line(2);
 
         $resources->each(function ($resource) use (&$contents) {
+            if(!$resource){
+                return;
+            }
+
             $contents .= $resource->getDefinition();
 
             if ($description = $resource->getDescription()) {


### PR DESCRIPTION
We've been annotating our routes with public/private tags like this, to produce two versions of the documentation where required.
`* @Versions({"api", "public"})`
`* @Versions({"api", "private"})`

However each controller was still getting outputted into the blueprint so we added a simple way to remove those resources which had no actions. 
