### PR TITLE
Bugfix: unicode support for json 

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -366,7 +366,7 @@ class Blueprint
     protected function prepareBody($body, $contentType)
     {
         if (strpos($contentType, 'application/json') === 0) {
-            return json_encode($body, JSON_PRETTY_PRINT);
+            return json_encode($body, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
         }
 
         return $body;


### PR DESCRIPTION
The default behavior of `json_encode` would Encode multibyte Unicode characters literally, but in this case, we can not using unicode characters in json response or request body, it will be convert to `\uXXXX` style characters, Obviously not what we expected

Sorry for my poor Engilsh skills.
