### PR TITLE
Support for Resource Groups

### DIFF
--- a/src/Action.php
+++ b/src/Action.php
@@ -61,7 +61,9 @@ class Action extends Section
             $definition = $identifier.' ['.$definition.']';
         }
 
-        return '## '.$definition;
+        $level = $this->resource->getGroupIdentifier() ? '### ' : '## ';
+
+        return $level.$definition;
     }
 
     /**

--- a/src/Annotation/Group.php
+++ b/src/Annotation/Group.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Dingo\Blueprint\Annotation;
+
+/**
+ * @Annotation
+ */
+class Group
+{
+    /**
+     * @var string
+     */
+    public $identifier;
+}

--- a/src/Group.php
+++ b/src/Group.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Dingo\Blueprint;
+
+use Illuminate\Support\Collection;
+
+class Group extends Section
+{
+    /**
+     * Group identifier.
+     *
+     * @var string
+     */
+    public $identifier = null;
+
+    /**
+     * Collection of resources belonging to group.
+     *
+     * @var array
+     */
+    protected $resources;
+
+    /**
+     * Create a new group instance.
+     *
+     * @param \Dingo\Blueprint\Resource $resource
+     *
+     * @return void
+     */
+    public function __construct(Resource $resource)
+    {
+        $this->resources = new Collection([$resource]);
+        $this->identifier = $resource->getGroupIdentifier();
+    }
+
+    /**
+     * Get the group identifier.
+     *
+     * @return string|null
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * Add resource to the group.
+     *
+     * @param \Dingo\Blueprint\Resource $resource
+     *
+     * @return void
+     */
+    public function addResource(Resource $resource)
+    {
+        $this->resources->contains($resource) ?: $this->resources->push($resource);
+    }
+
+    /**
+     * Get the resources belonging to the group.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getResources()
+    {
+        return $this->resources;
+    }
+
+    /**
+     * Get the group definition.
+     *
+     * @return string
+     */
+    public function getDefinition()
+    {
+        if ($this->identifier) {
+            return '# Group '.$this->identifier;
+        }
+    }
+}

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -95,7 +95,31 @@ class Resource extends Section
             $definition = $method.' '.$definition;
         }
 
-        return '# '.$this->getIdentifier().($definition == '/' ? '' : ' ['.$definition.']');
+        $level = $this->getGroupIdentifier() ? '## ' : '# ';
+
+        return $level.$this->getIdentifier().($definition == '/' ? '' : ' ['.$definition.']');
+    }
+
+    /**
+     * Get the resource group annotation.
+     *
+     * @return \Dingo\Blueprint\Annotation\Group
+     */
+    public function getGroupAnnotation()
+    {
+        return $this->getAnnotationByType('Group');
+    }
+
+    /**
+     * Get the resource group.
+     *
+     * @return string
+     */
+    public function getGroupIdentifier()
+    {
+        if (($annotation = $this->getGroupAnnotation()) && isset($annotation->identifier)) {
+            return $annotation->identifier;
+        }
     }
 
     /**

--- a/tests/BlueprintTest.php
+++ b/tests/BlueprintTest.php
@@ -204,13 +204,15 @@ Create a new user.
                 }
             }
 
-# User Photos [/users/{userId}/photos]
+# Group Photo Functions
+
+## User Photos [/users/{userId}/photos]
 User Photos Resource.
 
 + Parameters
     + userId: (integer, required) - ID of user who owns the photos.
 
-## Show all photos. [GET /users/{userId}/photos{?sort,order}]
+### Show all photos. [GET /users/{userId}/photos{?sort,order}]
 Show all photos for a given user.
 
 + Parameters
@@ -233,7 +235,7 @@ Show all photos for a given user.
                 }
             ]
 
-## Upload new photo. [POST /users/{userId}/photos]
+### Upload new photo. [POST /users/{userId}/photos]
 Upload a new photo for a given user.
 
 + Attributes
@@ -363,13 +365,15 @@ Create a new user.
                 }
             }
 
-# User Photos [/users/{userId}/photos]
+# Group Photo Functions
+
+## User Photos [/users/{userId}/photos]
 User Photos Resource.
 
 + Parameters
     + userId: (integer, required) - ID of user who owns the photos.
 
-## Show all photos. [GET /users/{userId}/photos{?sort,order}]
+### Show all photos. [GET /users/{userId}/photos{?sort,order}]
 Show all photos for a given user.
 
 + Parameters
@@ -392,7 +396,7 @@ Show all photos for a given user.
                 }
             ]
 
-## Show individual photo. [GET /users/{userId}/photos/{photoId}]
+### Show individual photo. [GET /users/{userId}/photos/{photoId}]
 Show an individual photo that belongs to a given user.
 
 + Parameters
@@ -419,7 +423,7 @@ Show an individual photo that belongs to a given user.
                 "message": "Photo could not be found."
             }
 
-## Upload new photo. [POST /users/{userId}/photos]
+### Upload new photo. [POST /users/{userId}/photos]
 Upload a new photo for a given user.
 
 + Attributes
@@ -450,7 +454,7 @@ Upload a new photo for a given user.
                 "message": "Could not upload photo due to errors."
             }
 
-## Delete photo. [DELETE /users/{userId}/photos/{photoId}]
+### Delete photo. [DELETE /users/{userId}/photos/{photoId}]
 Delete an existing photo for a given user.
 
 + Parameters

--- a/tests/Stubs/UserPhotosResourceStub.php
+++ b/tests/Stubs/UserPhotosResourceStub.php
@@ -5,6 +5,7 @@ namespace Dingo\Blueprint\Tests\Stubs;
 /**
  * User Photos Resource.
  *
+ * @Group("Photo Functions")
  * @Resource("User Photos", uri="/users/{userId}/photos")
  * @Parameters({
  *      @Parameter("userId", description="ID of user who owns the photos.", type="integer", required=true)


### PR DESCRIPTION
Added support for Resource Groups by extending the ideas discuss in #6 . 

This implementation introduces a Group annotation and a Group section object so that multiple different resources can be associated to the same group. This allows levels to be tracked so that the Markdown header levels can be properly increased for any Resource or Action belonging to a Group.

If there are any resources without a group, they appear at the top of the generated documentation otherwise they would be associated with the last group since Resources are considered part of the previous group until another one is defined.

This doesn't add a Group description yet. This could be unusual to handle since there could incorrectly be differing descriptions on different controllers. The first description encountered could be used. 

Another option to enhance this would be a sort priority so that groups could be arranged in a desired order.
