### PR TITLE
update generate() to optionilize includePath

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -80,7 +80,7 @@ class Blueprint
      *
      * @return bool
      */
-    public function generate(Collection $controllers, $name, $version, $includePath=null)
+    public function generate(Collection $controllers, $name, $version, $includePath = null)
     {
         $this->includePath = $includePath;
 

--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -80,7 +80,7 @@ class Blueprint
      *
      * @return bool
      */
-    public function generate(Collection $controllers, $name, $version, $includePath=__DIR__)
+    public function generate(Collection $controllers, $name, $version, $includePath=null)
     {
         $this->includePath = $includePath;
 

--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -80,7 +80,7 @@ class Blueprint
      *
      * @return bool
      */
-    public function generate(Collection $controllers, $name, $version, $includePath)
+    public function generate(Collection $controllers, $name, $version, $includePath=__DIR__)
     {
         $this->includePath = $includePath;
 

--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -405,7 +405,7 @@ class Blueprint
                 $path .= '.json';
             }
 
-            $body = $this->files->get($includePath.'/'.$path);
+            $body = $this->files->get($this->includePath.'/'.$path);
 
             json_decode($body);
 


### PR DESCRIPTION
This method is called from `Dingo/API/src/Console/Command/Docs.php:93` without a 4th argument. This PR was tested and indeed generated a valid blueprint.
