### PR TITLE
Upgrading DocBlock to 3.1.x for use with Laravel 5.2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "drmyersii/dingo-blueprint",
-    "description": "My maintained version of Dingo Blueprint, a generator for valid API Blueprint documentation.",
+    "name": "dingo/blueprint",
+    "description": "API Blueprint documentation generator.",
     "keywords": ["blueprint", "api", "laravel", "dingo", "docs"],
     "license": "BSD-3-Clause",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "dingo/blueprint",
-    "description": "API Blueprint documentation generator.",
+    "name": "drmyersii/dingo-blueprint",
+    "description": "My maintained version of Dingo Blueprint, a generator for valid API Blueprint documentation.",
     "keywords": ["blueprint", "api", "laravel", "dingo", "docs"],
     "license": "BSD-3-Clause",
     "authors": [
@@ -11,10 +11,10 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "~5.1",
-        "illuminate/filesystem": "~5.1",
+        "illuminate/support": "~5.1 || 5.2.*",
+        "illuminate/filesystem": "~5.1 || 5.2.*",
         "doctrine/annotations": "1.2.*",
-        "phpdocumentor/reflection-docblock": "2.0.*"
+        "phpdocumentor/reflection-docblock": "2.0.* || 3.1.*"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "~2.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "illuminate/support": "~5.1 || 5.2.*",
         "illuminate/filesystem": "~5.1 || 5.2.*",
         "doctrine/annotations": "1.2.*",
-        "phpdocumentor/reflection-docblock": "2.0.* || 3.1.*"
+        "phpdocumentor/reflection-docblock": "3.1.*"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "~2.0",

--- a/src/Action.php
+++ b/src/Action.php
@@ -5,7 +5,7 @@ namespace Dingo\Blueprint;
 use RuntimeException;
 use ReflectionMethod;
 use Illuminate\Support\Collection;
-use phpDocumentor\Reflection\DocBlock;
+use PhpDocumentor\Reflection\DocBlock;
 
 class Action extends Section
 {

--- a/src/Action.php
+++ b/src/Action.php
@@ -119,7 +119,10 @@ class Action extends Section
      */
     public function getIdentifier()
     {
-        return (new DocBlock($this->reflector))->getShortDescription();
+        $factory = \phpDocumentor\Reflection\DocBlockFactory::createInstance();
+        $docblock = $factory->create($this->reflector);
+
+        return $docblock->getSummary();
     }
 
     /**
@@ -129,7 +132,10 @@ class Action extends Section
      */
     public function getDescription()
     {
-        return (new DocBlock($this->reflector))->getLongDescription();
+        $factory = \phpDocumentor\Reflection\DocBlockFactory::createInstance();
+        $docblock = $factory->create($this->reflector);
+
+        return $docblock->getDescription();
     }
 
     /**

--- a/src/Action.php
+++ b/src/Action.php
@@ -5,7 +5,6 @@ namespace Dingo\Blueprint;
 use RuntimeException;
 use ReflectionMethod;
 use Illuminate\Support\Collection;
-use PhpDocumentor\Reflection\DocBlock;
 
 class Action extends Section
 {

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -4,7 +4,7 @@ namespace Dingo\Blueprint;
 
 use Illuminate\Support\Collection;
 use ReflectionClass;
-use phpDocumentor\Reflection\DocBlock;
+use PhpDocumentor\Reflection\DocBlock;
 
 class Resource extends Section
 {
@@ -144,7 +144,7 @@ class Resource extends Section
         $factory = \phpDocumentor\Reflection\DocBlockFactory::createInstance();
         $docblock = $factory->create($this->reflector);
 
-        $text = $docblock->getSummary() . "\n\n" . $docblock->getDescription();
+        $text = $docblock->getSummary()."\n\n".$docblock->getDescription();
 
         return $text;
     }

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -4,7 +4,6 @@ namespace Dingo\Blueprint;
 
 use Illuminate\Support\Collection;
 use ReflectionClass;
-use PhpDocumentor\Reflection\DocBlock;
 
 class Resource extends Section
 {

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -143,7 +143,7 @@ class Resource extends Section
         $factory = \phpDocumentor\Reflection\DocBlockFactory::createInstance();
         $docblock = $factory->create($this->reflector);
 
-        $text = $docblock->getSummary()."\n\n".$docblock->getDescription();
+        $text = $docblock->getSummary().$docblock->getDescription();
 
         return $text;
     }

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -141,7 +141,12 @@ class Resource extends Section
      */
     public function getDescription()
     {
-        return (new DocBlock($this->reflector))->getText();
+        $factory = \phpDocumentor\Reflection\DocBlockFactory::createInstance();
+        $docblock = $factory->create($this->reflector);
+
+        $text = $docblock->getSummary() . "\n\n" . $docblock->getDescription();
+
+        return $text;
     }
 
     /**


### PR DESCRIPTION
In order to use `dingo/api` and `dingo/blueprint` with Laravel 5.2, we need to be able to use the `phpdocumentor/reflection-docblock` package at version 3.1.x. This PR updates that dependency requirement as well as the necessary instantiation and method changes for version 3. 

I would recommend you tag the current dev release (probably at v0.1.6), merge the PR, and then tag the new release as a minor bump (probably at v0.2.0). In order to get this working with `dingo/api`, you will just need to change the package requirements for `dingo/blueprint` and 'phpdocumentor/reflection-docblock`. 

Unless it is explicitly required for Dingo API itself, I would also recommend removing the package requirement for `phpdocumentor/reflection-docblock` in `dingo/api` since `dingo/blueprint` already has that dependency requirement set.

Thanks for all the awesome work!
