### PR TITLE
Rename Resource class name

### DIFF
--- a/src/Action.php
+++ b/src/Action.php
@@ -25,7 +25,7 @@ class Action extends Section
     /**
      * Parent resource of the action.
      *
-     * @var \Dingo\Blueprint\Resource
+     * @var \Dingo\Blueprint\RestResource
      */
     protected $resource;
 
@@ -178,11 +178,11 @@ class Action extends Section
     /**
      * Set the parent resource on the action.
      *
-     * @param \Dingo\Blueprint\Resource $resource
+     * @param \Dingo\Blueprint\RestResource $resource
      *
      * @return void
      */
-    public function setResource(Resource $resource)
+    public function setResource(RestResource $resource)
     {
         $this->resource = $resource;
     }

--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -108,7 +108,7 @@ class Blueprint
 
             $annotations = new Collection($this->reader->getClassAnnotations($controller));
 
-            return new Resource($controller->getName(), $controller, $annotations, $actions);
+            return new RestResource($controller->getName(), $controller, $annotations, $actions);
         });
 
         $contents = $this->generateContentsFromResources($resources, $name);
@@ -268,11 +268,11 @@ class Blueprint
      *
      * @param string                               $contents
      * @param \Dingo\Blueprint\Annotation\Response $response
-     * @param \Dingo\Blueprint\Resource            $resource
+     * @param \Dingo\Blueprint\RestResource            $resource
      *
      * @return void
      */
-    protected function appendResponse(&$contents, Annotation\Response $response, Resource $resource)
+    protected function appendResponse(&$contents, Annotation\Response $response, RestResource $resource)
     {
         $this->appendSection($contents, sprintf('Response %s', $response->statusCode));
 
@@ -298,11 +298,11 @@ class Blueprint
      *
      * @param string                              $contents
      * @param \Dingo\Blueprint\Annotation\Request $request
-     * @param \Dingo\Blueprint\Resource           $resource
+     * @param \Dingo\Blueprint\RestResource           $resource
      *
      * @return void
      */
-    protected function appendRequest(&$contents, $request, Resource $resource)
+    protected function appendRequest(&$contents, $request, RestResource $resource)
     {
         $this->appendSection($contents, 'Request');
 

--- a/src/RestResource.php
+++ b/src/RestResource.php
@@ -5,7 +5,7 @@ namespace Dingo\Blueprint;
 use Illuminate\Support\Collection;
 use ReflectionClass;
 
-class Resource extends Section
+class RestResource extends Section
 {
     /**
      * Resource identifier.


### PR DESCRIPTION
Rename class name resource to RestResource

Renamed Resource class to RestResource and updated all references to
the class in code.

Resource is a soft reserved keyword. Usage is highly discouraged as it
may be used in future versions of PHP.
http://php.net/manual/en/reserved.other-reserved-words.php

Resolves: #46