### PR TITLE
Allow use of laravel 5.4 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "5.1.* || 5.2.* || 5.3.*",
-        "illuminate/filesystem": "5.1.* || 5.2.* || 5.3.*",
+        "illuminate/support": "5.1.* || 5.2.* || 5.3.* || 5.4.*",
+        "illuminate/filesystem": "5.1.* || 5.2.* || 5.3.* || 5.4.*",
         "doctrine/annotations": "~1.2",
         "phpdocumentor/reflection-docblock": "3.1.*"
     },


### PR DESCRIPTION
This PR updates the composer version constraints to allow illuminate 5.4 components.