### PR TITLE
Add group notation - #33 improvement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 php:
   - 5.5.9
   - 5.5

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,8 @@ Some index method phpdoc example:
 /**
  * Products
  *
+ * @Group("Products")
+ * @Versions({"v1"})
  * @Resource("Products", uri="/products")
 */
 class ProductsController extends ApiController

--- a/src/Action.php
+++ b/src/Action.php
@@ -60,7 +60,9 @@ class Action extends Section
             $definition = $identifier.' ['.$definition.']';
         }
 
-        return '## '.$definition;
+        $level = $this->resource->getGroupIdentifier() ? '### ' : '## ';
+
+        return $level.$definition;
     }
 
     /**

--- a/src/Annotation/Group.php
+++ b/src/Annotation/Group.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Dingo\Blueprint\Annotation;
+
+/**
+ * @Annotation
+ */
+class Group
+{
+    /**
+     * @var string
+     */
+    public $identifier;
+}

--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -84,7 +84,9 @@ class Blueprint
     {
         $this->includePath = $includePath;
 
-        $resources = $controllers->map(function ($controller) use ($version) {
+        $groups = new Collection;
+
+        $resources = $controllers->map(function ($controller) use ($version, $groups) {
             $controller = $controller instanceof ReflectionClass ? $controller : new ReflectionClass($controller);
 
             $actions = new Collection;
@@ -108,10 +110,33 @@ class Blueprint
 
             $annotations = new Collection($this->reader->getClassAnnotations($controller));
 
-            return new Resource($controller->getName(), $controller, $annotations, $actions);
+            $versions = $annotations->filter(function($item) {
+                return $item instanceof Annotation\Versions;
+            })->first();
+
+            // if the group does not have the intended version, the group is skipped
+            if( isset($versions->value) && in_array($version, $versions->value) )
+            {
+                $resource = new Resource($controller->getName(), $controller, $annotations, $actions);
+
+                // Find or create group and add resource to it
+                $group = $groups->where('identifier', $resource->getGroupIdentifier())->first() ?: new Group($resource);
+                $group->addResource($resource);
+                if (! $resource->getGroupIdentifier()) {
+                    // Prepend resource group with no identifier so this group appears first
+                    $groups->contains($group) ?: $groups->prepend($group);
+                } else {
+                    $groups->contains($group) ?: $groups->push($group);
+                }
+
+                return $resource;
+            }
+
+
+            return false;
         });
 
-        $contents = $this->generateContentsFromResources($resources, $name);
+        $contents = $this->generateContentsFromGroups($groups, $name);
 
         $this->includePath = null;
 
@@ -119,14 +144,14 @@ class Blueprint
     }
 
     /**
-     * Generate the documentation contents from the resources collection.
+     * Generate the documentation contents from the groups collection.
      *
-     * @param \Illuminate\Support\Collection $resources
+     * @param \Illuminate\Support\Collection $groups
      * @param string                         $name
      *
      * @return string
      */
-    protected function generateContentsFromResources(Collection $resources, $name)
+    protected function generateContentsFromGroups(Collection $groups, $name)
     {
         $contents = '';
 
@@ -135,61 +160,70 @@ class Blueprint
         $contents .= sprintf('# %s', $name);
         $contents .= $this->line(2);
 
-        $resources->each(function ($resource) use (&$contents) {
-            if ($resource->getActions()->isEmpty()) {
-                return;
-            }
+        $groups->each(function ($group) use (&$contents) {
 
-            $contents .= $resource->getDefinition();
-
-            if ($description = $resource->getDescription()) {
-                $contents .= $this->line();
-                $contents .= $description;
-            }
-
-            if (($parameters = $resource->getParameters()) && ! $parameters->isEmpty()) {
-                $this->appendParameters($contents, $parameters);
-            }
-
-            $resource->getActions()->each(function ($action) use (&$contents, $resource) {
+            if ($group->getIdentifier()) {
+                $contents .= $group->getDefinition();
                 $contents .= $this->line(2);
-                $contents .= $action->getDefinition();
+            }
 
-                if ($description = $action->getDescription()) {
+            $group->getResources()->each(function ($resource) use (&$contents) {
+
+                if ($resource->getActions()->isEmpty()) {
+                    return;
+                }
+
+                $contents .= $resource->getDefinition();
+
+                if ($description = $resource->getDescription()) {
                     $contents .= $this->line();
                     $contents .= $description;
                 }
 
-                if (($attributes = $action->getAttributes()) && ! $attributes->isEmpty()) {
-                    $this->appendAttributes($contents, $attributes);
-                }
-
-                if (($parameters = $action->getParameters()) && ! $parameters->isEmpty()) {
+                if (($parameters = $resource->getParameters()) && ! $parameters->isEmpty()) {
                     $this->appendParameters($contents, $parameters);
                 }
 
-                if ($request = $action->getRequest()) {
-                    $this->appendRequest($contents, $request, $resource);
-                }
+                $resource->getActions()->each(function ($action) use (&$contents, $resource) {
+                    $contents .= $this->line(2);
+                    $contents .= $action->getDefinition();
 
-                if ($response = $action->getResponse()) {
-                    $this->appendResponse($contents, $response, $resource);
-                }
+                    if ($description = $action->getDescription()) {
+                        $contents .= $this->line();
+                        $contents .= $description;
+                    }
 
-                if ($transaction = $action->getTransaction()) {
-                    foreach ($transaction->value as $value) {
-                        if ($value instanceof Annotation\Request) {
-                            $this->appendRequest($contents, $value, $resource);
-                        } elseif ($value instanceof Annotation\Response) {
-                            $this->appendResponse($contents, $value, $resource);
-                        } else {
-                            throw new RuntimeException('Unsupported annotation type given in transaction.');
+                    if (($attributes = $action->getAttributes()) && ! $attributes->isEmpty()) {
+                        $this->appendAttributes($contents, $attributes);
+                    }
+
+                    if (($parameters = $action->getParameters()) && ! $parameters->isEmpty()) {
+                        $this->appendParameters($contents, $parameters);
+                    }
+
+                    if ($request = $action->getRequest()) {
+                        $this->appendRequest($contents, $request, $resource);
+                    }
+
+                    if ($response = $action->getResponse()) {
+                        $this->appendResponse($contents, $response, $resource);
+                    }
+
+                    if ($transaction = $action->getTransaction()) {
+                        foreach ($transaction->value as $value) {
+                            if ($value instanceof Annotation\Request) {
+                                $this->appendRequest($contents, $value, $resource);
+                            } elseif ($value instanceof Annotation\Response) {
+                                $this->appendResponse($contents, $value, $resource);
+                            } else {
+                                throw new RuntimeException('Unsupported annotation type given in transaction.');
+                            }
                         }
                     }
-                }
-            });
+                });
 
-            $contents .= $this->line(2);
+                $contents .= $this->line(2);
+            });
         });
 
         return stripslashes(trim($contents));
@@ -405,7 +439,7 @@ class Blueprint
                 $path .= '.json';
             }
 
-            $body = $this->files->get($this->includePath.'/'.$path);
+            $body = $this->files->get($includePath.'/'.$path);
 
             json_decode($body);
 

--- a/src/Group.php
+++ b/src/Group.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Dingo\Blueprint;
+
+use Illuminate\Support\Collection;
+
+class Group extends Section
+{
+    /**
+     * Group identifier.
+     *
+     * @var string
+     */
+    public $identifier = null;
+
+    /**
+     * Collection of resources belonging to group.
+     *
+     * @var array
+     */
+    protected $resources;
+
+    /**
+     * Create a new group instance.
+     *
+     * @param \Dingo\Blueprint\Resource $resource
+     *
+     * @return void
+     */
+    public function __construct(Resource $resource)
+    {
+        $this->resources = new Collection([$resource]);
+        $this->identifier = $resource->getGroupIdentifier();
+    }
+
+    /**
+     * Get the group identifier.
+     *
+     * @return string|null
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * Add resource to the group.
+     *
+     * @param \Dingo\Blueprint\Resource $resource
+     *
+     * @return void
+     */
+    public function addResource(Resource $resource)
+    {
+        $this->resources->contains($resource) ?: $this->resources->push($resource);
+    }
+
+    /**
+     * Get the resources belonging to the group.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getResources()
+    {
+        return $this->resources;
+    }
+
+    /**
+     * Get the group definition.
+     *
+     * @return string
+     */
+    public function getDefinition()
+    {
+        if ($this->identifier) {
+            return '# Group '.$this->identifier;
+        }
+    }
+}

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -4,6 +4,7 @@ namespace Dingo\Blueprint;
 
 use Illuminate\Support\Collection;
 use ReflectionClass;
+use phpDocumentor\Reflection\DocBlock;
 
 class Resource extends Section
 {
@@ -94,7 +95,31 @@ class Resource extends Section
             $definition = $method.' '.$definition;
         }
 
-        return '# '.$this->getIdentifier().($definition == '/' ? '' : ' ['.$definition.']');
+        $level = $this->getGroupIdentifier() ? '## ' : '# ';
+
+        return $level.$this->getIdentifier().($definition == '/' ? '' : ' ['.$definition.']');
+    }
+
+    /**
+     * Get the resource group annotation.
+     *
+     * @return \Dingo\Blueprint\Annotation\Group
+     */
+    public function getGroupAnnotation()
+    {
+        return $this->getAnnotationByType('Group');
+    }
+
+    /**
+     * Get the resource group.
+     *
+     * @return string
+     */
+    public function getGroupIdentifier()
+    {
+        if (($annotation = $this->getGroupAnnotation()) && isset($annotation->identifier)) {
+            return $annotation->identifier;
+        }
     }
 
     /**
@@ -142,9 +167,7 @@ class Resource extends Section
     {
         $factory = \phpDocumentor\Reflection\DocBlockFactory::createInstance();
         $docblock = $factory->create($this->reflector);
-
         $text = $docblock->getSummary().$docblock->getDescription();
-
         return $text;
     }
 

--- a/tests/BlueprintTest.php
+++ b/tests/BlueprintTest.php
@@ -21,10 +21,12 @@ FORMAT: 1A
 
 # testing
 
-# Users [/users]
+# Group User
+
+## Users [/users]
 Users Resource.
 
-## Show all users. [GET /users]
+### Show all users. [GET /users]
 Get a JSON representation of all registered users.
 
 + Request (application/json)
@@ -46,7 +48,7 @@ Get a JSON representation of all registered users.
                 }
             ]
 
-## Show existing user. [GET /users/{id}]
+### Show existing user. [GET /users/{id}]
 Get a JSON representation of an existing user.
 
 + Parameters
@@ -67,7 +69,7 @@ Get a JSON representation of an existing user.
                 "message": "User could not be found."
             }
 
-## Create new user. [POST /users]
+### Create new user. [POST /users]
 Create a new user.
 
 + Request (application/json)
@@ -120,10 +122,12 @@ FORMAT: 1A
 
 # testing
 
-# Users [/users]
+# Group User
+
+## Users [/users]
 Users Resource.
 
-## Show all users. [GET /users]
+### Show all users. [GET /users]
 Get a JSON representation of all registered users.
 
 + Request (application/json)
@@ -145,7 +149,7 @@ Get a JSON representation of all registered users.
                 }
             ]
 
-## Show existing user. [GET /users/{id}]
+### Show existing user. [GET /users/{id}]
 Get a JSON representation of an existing user.
 
 + Parameters
@@ -166,7 +170,7 @@ Get a JSON representation of an existing user.
                 "message": "User could not be found."
             }
 
-## Create new user. [POST /users]
+### Create new user. [POST /users]
 Create a new user.
 
 + Request (application/json)
@@ -204,13 +208,13 @@ Create a new user.
                 }
             }
 
-# User Photos [/users/{userId}/photos]
+## User Photos [/users/{userId}/photos]
 User Photos Resource.
 
 + Parameters
     + userId: (integer, required) - ID of user who owns the photos.
 
-## Show all photos. [GET /users/{userId}/photos{?sort,order}]
+### Show all photos. [GET /users/{userId}/photos{?sort,order}]
 Show all photos for a given user.
 
 + Parameters
@@ -233,7 +237,7 @@ Show all photos for a given user.
                 }
             ]
 
-## Upload new photo. [POST /users/{userId}/photos]
+### Upload new photo. [POST /users/{userId}/photos]
 Upload a new photo for a given user.
 
 + Attributes
@@ -279,10 +283,12 @@ FORMAT: 1A
 
 # testing
 
-# Users [/users]
+# Group User
+
+## Users [/users]
 Users Resource.
 
-## Show all users. [GET /users]
+### Show all users. [GET /users]
 Get a JSON representation of all registered users.
 
 + Request (application/json)
@@ -304,7 +310,7 @@ Get a JSON representation of all registered users.
                 }
             ]
 
-## Show existing user. [GET /users/{id}]
+### Show existing user. [GET /users/{id}]
 Get a JSON representation of an existing user.
 
 + Parameters
@@ -325,7 +331,7 @@ Get a JSON representation of an existing user.
                 "message": "User could not be found."
             }
 
-## Create new user. [POST /users]
+### Create new user. [POST /users]
 Create a new user.
 
 + Request (application/json)
@@ -363,13 +369,13 @@ Create a new user.
                 }
             }
 
-# User Photos [/users/{userId}/photos]
+## User Photos [/users/{userId}/photos]
 User Photos Resource.
 
 + Parameters
     + userId: (integer, required) - ID of user who owns the photos.
 
-## Show all photos. [GET /users/{userId}/photos{?sort,order}]
+### Show all photos. [GET /users/{userId}/photos{?sort,order}]
 Show all photos for a given user.
 
 + Parameters
@@ -392,7 +398,7 @@ Show all photos for a given user.
                 }
             ]
 
-## Show individual photo. [GET /users/{userId}/photos/{photoId}]
+### Show individual photo. [GET /users/{userId}/photos/{photoId}]
 Show an individual photo that belongs to a given user.
 
 + Parameters
@@ -419,7 +425,7 @@ Show an individual photo that belongs to a given user.
                 "message": "Photo could not be found."
             }
 
-## Upload new photo. [POST /users/{userId}/photos]
+### Upload new photo. [POST /users/{userId}/photos]
 Upload a new photo for a given user.
 
 + Attributes
@@ -450,7 +456,7 @@ Upload a new photo for a given user.
                 "message": "Could not upload photo due to errors."
             }
 
-## Delete photo. [DELETE /users/{userId}/photos/{photoId}]
+### Delete photo. [DELETE /users/{userId}/photos/{photoId}]
 Delete an existing photo for a given user.
 
 + Parameters
@@ -480,9 +486,11 @@ FORMAT: 1A
 
 # testing
 
-# Activity
+# Group Activity
 
-## Show all activities. [GET /activity]
+## Activity
+
+### Show all activities. [GET /activity]
 EOT;
 
         $this->assertEquals(trim($expected), $blueprint->generate($resources, 'testing', 'v1', null));

--- a/tests/LaravelIntegrationTest.php
+++ b/tests/LaravelIntegrationTest.php
@@ -53,9 +53,11 @@ FORMAT: 1A
 
 # testing
 
-# Activity
+# Group Activity
 
-## Show all activities. [GET /activity]
+## Activity
+
+### Show all activities. [GET /activity]
 EOT;
 
         public function testGetAnnotationByTypeInLaravel52x()

--- a/tests/Stubs/ActivityController.php
+++ b/tests/Stubs/ActivityController.php
@@ -3,6 +3,8 @@
 namespace Dingo\Blueprint\Tests\Stubs;
 
 /**
+ * @Group("Activity")
+ * @Versions({"v1"})
  * @Resource("Activity")
  */
 class ActivityController
@@ -11,6 +13,7 @@ class ActivityController
      * Show all activities.
      *
      * @Get("activity")
+     * @Versions({"v1"})
      */
     public function getIndex()
     {

--- a/tests/Stubs/UserPhotosResourceStub.php
+++ b/tests/Stubs/UserPhotosResourceStub.php
@@ -5,6 +5,8 @@ namespace Dingo\Blueprint\Tests\Stubs;
 /**
  * User Photos Resource.
  *
+ * @Group("User")
+ * @Versions({"v1", "v2"})
  * @Resource("User Photos", uri="/users/{userId}/photos")
  * @Parameters({
  *      @Parameter("userId", description="ID of user who owns the photos.", type="integer", required=true)

--- a/tests/Stubs/UsersResourceStub.php
+++ b/tests/Stubs/UsersResourceStub.php
@@ -5,6 +5,8 @@ namespace Dingo\Blueprint\Tests\Stubs;
 /**
  * Users Resource.
  *
+ * @Group("User")
+ * @Versions({"v1","v2"})
  * @Resource("Users", uri="/users")
  */
 class UsersResourceStub


### PR DESCRIPTION
Added support for Resource Groups, version based.

This implementation is nothing new. It's a combination of the solution provided by #33 and by the need raised in #41.

Basically, it allows having group annotation for a specific documentation version, instead of appearing by default in every version. 

With this change, it's mandatory to have a version in the controller comments (see example below). Without it, the methods specified in the controller will not be considered, even if the right documentation version was added.

Following the tests already in place, here's an example of how the group and version resources can be used combined:

```
/**
 * User Photos Resource.
 *
 * @Group("User")
 * @Versions({"v1", "v2"})
 * @Resource("User Photos", uri="/users/{userId}/photos")
 * @Parameters({
 *      @Parameter("userId", description="ID of user who owns the photos.", type="integer", required=true)
 * })
 */
class UserPhotosResourceStub
{
    /**
     * Show all photos.
     *
     * Show all photos for a given user.
     *
     * @Get("/{?sort,order}")
     * @Parameters({
     *      @Parameter("sort", description="Column to sort by.", type="string", default="name"),
     *      @Parameter("order", description="Order of results, either `asc` or `desc`.", type="string", default="desc", members={
     *          @Member("asc", description="Ascending order."),
     *          @Member("desc", description="Descending order."),
     *      })
     * })
     * @Versions({"v1", "v2"})
     * @Response(200, body={
     *      {"id": 1, "name": "photo", "src": "path/to/cool/photo.jpg"}
     * })
     */
    public function index($userId)
    {
        //
    }
}
```