### PR TITLE
Ability to include an external file as overview section.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 php:
   - 5.5.9
   - 5.5

--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -80,7 +80,7 @@ class Blueprint
      *
      * @return bool
      */
-    public function generate(Collection $controllers, $name, $version, $includePath = null)
+    public function generate(Collection $controllers, $name, $version, $includePath = null, $overviewFile = null)
     {
         $this->includePath = $includePath;
 
@@ -111,7 +111,7 @@ class Blueprint
             return new Resource($controller->getName(), $controller, $annotations, $actions);
         });
 
-        $contents = $this->generateContentsFromResources($resources, $name);
+        $contents = $this->generateContentsFromResources($resources, $name, $overviewFile);
 
         $this->includePath = null;
 
@@ -123,10 +123,11 @@ class Blueprint
      *
      * @param \Illuminate\Support\Collection $resources
      * @param string                         $name
+     * @param string                         $overviewFile
      *
      * @return string
      */
-    protected function generateContentsFromResources(Collection $resources, $name)
+    protected function generateContentsFromResources(Collection $resources, $name, $overviewFile = null)
     {
         $contents = '';
 
@@ -134,6 +135,7 @@ class Blueprint
         $contents .= $this->line(2);
         $contents .= sprintf('# %s', $name);
         $contents .= $this->line(2);
+        $contents .= $this->getOverview($overviewFile);
 
         $resources->each(function ($resource) use (&$contents) {
             if ($resource->getActions()->isEmpty()) {
@@ -453,5 +455,30 @@ class Blueprint
     protected function getFormat()
     {
         return 'FORMAT: 1A';
+    }
+
+    /**
+     * Get the overview file content to append.
+     *
+     * @param null $file
+     * @return null|string
+     */
+    protected function getOverview($file = null)
+    {
+        if (null !== $file) {
+            if (!file_exists($file)) {
+                throw new RuntimeException('Overview file could not be found.');
+            }
+
+            $content = file_get_contents($file);
+
+            if ($content === false) {
+                throw new RuntimeException('Failed to read overview file contents.');
+            }
+
+            return $content.$this->line(2);
+        }
+
+        return null;
     }
 }

--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -71,12 +71,13 @@ class Blueprint
     }
 
     /**
-     * Generate documentation with the name and version.
+     * Generate documentation with the name, version and optional overview content.
      *
      * @param \Illuminate\Support\Collection $controllers
      * @param string                         $name
      * @param string                         $version
      * @param string                         $includePath
+     * @param string                         $overviewFile
      *
      * @return bool
      */

--- a/tests/BlueprintTest.php
+++ b/tests/BlueprintTest.php
@@ -487,4 +487,27 @@ EOT;
 
         $this->assertEquals(trim($expected), $blueprint->generate($resources, 'testing', 'v1', null));
     }
+
+    public function testGeneratingBlueprintOverview()
+    {
+        $resources = new Collection([new Stubs\ActivityController]);
+
+        $blueprint = new Blueprint(new SimpleAnnotationReader, new Filesystem);
+
+        $expected = <<<'EOT'
+FORMAT: 1A
+
+# testing
+
+Overview content here.
+
+# Activity
+
+## Show all activities. [GET /activity]
+EOT;
+
+        $this->assertEquals(trim($expected), $blueprint->generate($resources, 'testing', 'v1', null, __DIR__.'/Files/overview.apib'));
+
+
+    }
 }

--- a/tests/Files/overview.apib
+++ b/tests/Files/overview.apib
@@ -1,0 +1,1 @@
+Overview content here.


### PR DESCRIPTION
Adds functionality to include a file (in API blueprint format) to be displayed at the top of the generated blueprint, under the title.

Additionally, the following changes can be made to the dingo/api Docs artisan command to allow cli generation that includes the overview, e.g.

`
php artisan api:docs --output-file blueprint.apib --overview-file=docs/overview.apib
`

These changes are reflected here:

[Docs.php.txt](https://github.com/dingo/blueprint/files/1112328/Docs.php.txt)

This is just one possible solution for #59 (Probably the most simplistic work around).