### PR TITLE
Update 'illuminate/*' version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "5.1.* || 5.2.* || 5.3.* || 5.4.*",
-        "illuminate/filesystem": "5.1.* || 5.2.* || 5.3.* || 5.4.*",
+        "illuminate/support": "^5.1",
+        "illuminate/filesystem": "^5.1",
         "doctrine/annotations": "~1.2",
         "phpdocumentor/reflection-docblock": "3.1.*"
     },


### PR DESCRIPTION
This mirrors changes made [on dingo/api](https://github.com/dingo/api/commit/46cffad61942caa094dd876155e503b6819c5095) so that this package supports Laravel 5.1 and above, including Laravel 5.5.

This change should also fix dingo/api installs for Laravel 5.5, since blueprint is a dependency.