### PR TITLE
Laravel 6.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "^5.1",
-        "illuminate/filesystem": "^5.1",
+        "illuminate/support": "^5.1 || ^6.0",
+        "illuminate/filesystem": "^5.1 || ^6.0",
         "doctrine/annotations": "~1.2",
         "phpdocumentor/reflection-docblock": "^3.1|^4.1"
     },

--- a/src/Action.php
+++ b/src/Action.php
@@ -2,6 +2,7 @@
 
 namespace Dingo\Blueprint;
 
+use Illuminate\Support\Str;
 use RuntimeException;
 use ReflectionMethod;
 use Illuminate\Support\Collection;
@@ -152,7 +153,7 @@ class Action extends Section
             return;
         }
 
-        if (! starts_with($uri, '{?')) {
+        if (! Str::startsWith($uri, '{?')) {
             $uri = '/'.$uri;
         }
 


### PR DESCRIPTION
### Changes
- Added logical OR in Illuminate packages to support versions `^6.0`

### Fixes
- Replace deprecated `illuminate/support` functions
  - `starts_with()` -> `Illuminate\Support\Str::startsWith()`