### PR TITLE
Allow Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,14 @@
     ],
     "require": {
         "php": "^7.2.5",
-        "illuminate/support": "^7.0",
-        "illuminate/filesystem": "^7.0",
+        "illuminate/support": "^7.0|^8.0",
+        "illuminate/filesystem": "^7.0|^8.0",
         "doctrine/annotations": "~1.2",
         "phpdocumentor/reflection-docblock": "^3.1 || ^4.1 || ^5"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "~2.0",
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^6.5|^8.3|^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
No major framework changes that I can see - tests running. Can be tagged as `v0.4.2`