### PR TITLE
Update composer.json PHP8.2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
         "php": "^7.2.5|^8.0",
         "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
         "illuminate/filesystem": "^7.0|^8.0|^9.0|^10.0",
-        "doctrine/annotations": "~1.2",
+        "doctrine/annotations": "~1.2 | ^2.0",
         "phpdocumentor/reflection-docblock": "^3.1 || ^4.1 || ^5"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "~2.0",
-        "phpunit/phpunit": "^6.5|^8.3|^9.0"
+        "phpunit/phpunit": "^6.5|^8.3|^9.0|^10.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Without doctrine/annotations >= 2 there is no way to have PHP 8.2 compatibility as doctrine/lexer is required in other packages which are locked with an old PHP version.